### PR TITLE
Synchronize device dropdown with table contents

### DIFF
--- a/Handyvergleich.html
+++ b/Handyvergleich.html
@@ -1482,6 +1482,40 @@
       }
     }
 
+    function collectDevicesFromContracts() {
+      return contracts
+        .map(contract => (contract.device || '').toString().trim())
+        .filter(Boolean);
+    }
+
+    function syncDevicesFromContracts({ persist = false } = {}) {
+      const uniqueDevices = Array.from(new Set(collectDevicesFromContracts()))
+        .sort((a, b) => a.localeCompare(b, 'de', { sensitivity: 'base' }));
+
+      const hasChanged =
+        uniqueDevices.length !== devices.length ||
+        uniqueDevices.some((device, index) => device !== devices[index]);
+
+      if (hasChanged) {
+        devices = uniqueDevices;
+        if (persist) {
+          saveDevices();
+        }
+      }
+
+      return hasChanged;
+    }
+
+    function refreshDeviceOptions(preferredValue = '', { sync = true } = {}) {
+      const previousSelection = preferredValue || deviceSelect.value || '';
+
+      if (sync) {
+        syncDevicesFromContracts({ persist: true });
+      }
+
+      populateDeviceOptions(previousSelection);
+    }
+
     function populateDeviceOptions(selected = '') {
       deviceSelect.innerHTML = '';
 
@@ -1532,6 +1566,7 @@
     let selectedIndex = null;
 
     function render() {
+      refreshDeviceOptions(deviceSelect.value);
       overview.innerHTML = '';
 
       if (!contracts.length) {
@@ -1787,7 +1822,7 @@
       editingIndex = null;
       submitButton.textContent = 'Vertrag hinzufügen';
       cancelEditButton.classList.add('hidden');
-      populateDeviceOptions(selectedDevice);
+      refreshDeviceOptions(selectedDevice);
       showNewDeviceInput(false);
       newDeviceInput.value = '';
     }
@@ -1824,7 +1859,7 @@
         saveDevices();
       }
 
-      populateDeviceOptions(contract.device || '');
+      refreshDeviceOptions(contract.device || '');
       fillFormWithContract(contract);
       submitButton.textContent = 'Vertrag aktualisieren';
       cancelEditButton.classList.remove('hidden');
@@ -1895,7 +1930,7 @@
             saveDevices();
           }
           device = newDevice;
-          populateDeviceOptions(device);
+          refreshDeviceOptions(device, { sync: false });
         } else {
           device = '';
         }


### PR DESCRIPTION
## Summary
- derive the device dropdown options from the current contracts before rendering the form
- refresh the select menu during form lifecycle changes so only phones present in the table remain selectable

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d98f1e4bf8832d80518a8cbf6d3c29