### PR TITLE
Allow editing selected contract from summary

### DIFF
--- a/Handyvergleich.html
+++ b/Handyvergleich.html
@@ -930,7 +930,7 @@
             <p id="selected-contract-subtitle"></p>
           </div>
           <div class="selected-contract-actions">
-            <button type="button" id="selected-update">Aktualisieren</button>
+            <button type="button" id="selected-update">Bearbeiten</button>
             <button type="button" class="button-secondary" id="selected-clear">Clear</button>
           </div>
         </div>
@@ -1786,6 +1786,22 @@
       }
     }
 
+    function focusFirstEditableField() {
+      const providerInput = form.elements['provider'];
+      if (providerInput && typeof providerInput.focus === 'function') {
+        providerInput.focus();
+        if (typeof providerInput.select === 'function') {
+          providerInput.select();
+        }
+        return;
+      }
+
+      const fallback = form.querySelector('input, select, textarea');
+      if (fallback && typeof fallback.focus === 'function') {
+        fallback.focus();
+      }
+    }
+
     deviceSelect.addEventListener('change', () => {
       showNewDeviceInput(deviceSelect.value === '__new__');
     });
@@ -1838,7 +1854,7 @@
       const selectedBonusEl = fragment.getElementById('selected-bonus');
       const selectedLinkEl = fragment.getElementById('selected-link');
       const selectedNotesEl = fragment.getElementById('selected-notes');
-      const selectedUpdateButton = fragment.getElementById('selected-update');
+      const selectedEditButton = fragment.getElementById('selected-update');
       const selectedClearButton = fragment.getElementById('selected-clear');
 
       if (sortSelect) {
@@ -1919,7 +1935,14 @@
             if (selectedIndex !== index) {
               selectedIndex = index;
               render();
+              return;
             }
+
+            if (editingIndex === index) {
+              return;
+            }
+
+            startEdit(index);
           });
         }
 
@@ -2042,8 +2065,8 @@
         }
       }
 
-      if (selectedUpdateButton) {
-        selectedUpdateButton.addEventListener('click', () => {
+      if (selectedEditButton) {
+        selectedEditButton.addEventListener('click', () => {
           if (selectedIndex !== null) {
             startEdit(selectedIndex);
           }
@@ -2106,8 +2129,18 @@
       fillFormWithContract(contract);
       submitButton.textContent = 'Vertrag aktualisieren';
       cancelEditButton.classList.remove('hidden');
-      form.scrollIntoView({ behavior: 'smooth', block: 'start' });
       render();
+
+      const focusAndScroll = () => {
+        form.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        focusFirstEditableField();
+      };
+
+      if (typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(focusAndScroll);
+      } else {
+        focusAndScroll();
+      }
     }
 
     function deleteContract(index) {


### PR DESCRIPTION
## Summary
- make the selected-contract action button a clear "Bearbeiten" entry point and wire it to the existing edit form
- allow clicking an already selected table row to jump into edit mode so chosen contracts are immediately editable
- focus the provider field when editing and keep the form in view for a smoother editing flow

## Testing
- Manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_68d99232c670832dbc5f6aead1f79031